### PR TITLE
[Fix] 新增对特殊zip分卷识别并检查文件数量

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -334,7 +334,7 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "lemmekk"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "lemmekk"
 description = "让我康康 - 批量解压工具"
 authors = ["Neko <neko@eroneko.eu.org>"]
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 default-run = "lemmekk"
 

--- a/src/appinfo/mod.rs
+++ b/src/appinfo/mod.rs
@@ -33,7 +33,7 @@ impl Default for AppInfo {
             lib_version: Version {
                 major: 0,
                 minor: 1,
-                revision: 6,
+                revision: 7,
                 edition: Edition::Dev,
             },
         }

--- a/src/config/provider.rs
+++ b/src/config/provider.rs
@@ -88,11 +88,15 @@ impl Default for DefaultRegex {
                 .build()
                 .unwrap(),
             split_pack_name: vec![
-                RegexBuilder::new(r"^(?<package>.*)\.part(?<vol>\d+).(:?rar|exe)$")
+                RegexBuilder::new(r"^(?<package>.*)\.part(?<vol>\d+)\.(:?rar|exe)$")
                     .case_insensitive(true)
                     .build()
                     .unwrap(),
-                RegexBuilder::new(r"^(?<package>.*).7z.(?<vol>\d{3,})$")
+                RegexBuilder::new(r"^(?<package>.*)\.(?:7z|zip|tar)\.(?<vol>\d{3,})$")
+                    .case_insensitive(true)
+                    .build()
+                    .unwrap(),
+                RegexBuilder::new(r"^(?<package>.*)\.z(?<vol>\d{2,})$")
                     .case_insensitive(true)
                     .build()
                     .unwrap(),


### PR DESCRIPTION
新增对 winrar 创建的 zip 分卷进行识别，文件名序列诸如：`["文件.z01", "文件.z02", "文件.zip"]`